### PR TITLE
Change sœurité's spelling

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,7 +4,7 @@ title : about
 header : about
 group: navigation
 weight : 1
-tagline: Liberté - Digitalité - <span title="[Sööö:höööö:rit'eeee]">Sœrité</span>
+tagline: Liberté - Digitalité - <span title="[Sööö:höööö:rit'eeee]">Sœurité</span>
 
 ---
 {% include JB/setup %}


### PR DESCRIPTION
Sœurité takes a U after the E dans l'O.

This could also be called _Sororité_.
