### PR TITLE
Fixes the css error locally

### DIFF
--- a/_includes/JB/setup
+++ b/_includes/JB/setup
@@ -16,7 +16,7 @@
     {% if site.JB.ASSET_PATH %}
       {% assign ASSET_PATH = site.JB.ASSET_PATH %}
     {% else %}
-      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ page.theme.name }}{% endcapture %}
-    {% endif %}  
+      {% capture ASSET_PATH %}{{ BASE_PATH }}/assets/themes/{{ layout.theme.name }}{% endcapture %}
+    {% endif %}
   {% endif %}
 {% endcapture %}{% assign jbcache = nil %}


### PR DESCRIPTION
See: https://github.com/plusjade/jekyll-bootstrap/issues/295

With that fix, CSS works on  my machine now. I have no clue if its working in production.
